### PR TITLE
create site directory on build

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -46,6 +46,9 @@ pub fn cargo_build(release: bool, output_dir: Option<&str>) -> Result<(), Error>
     // Hopefully. Should handle this better later.
     let filename = wasm.file_name().unwrap().to_str().unwrap();
     let target_dir = output_dir.unwrap_or("site");
+    if target_dir == "site" {
+        fs::create_dir_all("/site")?;
+    }
     let path = format!("{}/{}", &target_dir, &filename);
     fs::copy(&wasm, &path)?;
 


### PR DESCRIPTION
## What's in this PR?

👋 Hi. I've been using this library as I'm learning WASM and it's been a huge help. One of the things I noticed was that when creating a new lib via cargo, the `site` directory is not created. If you then come across this library and try `cargo wasm build` you get this error:

<img width="383" alt="screen shot 2018-05-29 at 8 46 19 pm" src="https://user-images.githubusercontent.com/881981/40692916-81bcb226-6382-11e8-9439-0027581ce803.png">

A simple `mkdir site` fixes it but it would be nice if the command created the folder if it didn't exist and no output directory is specified.